### PR TITLE
将新建的前端项目添加到自动同步的脚本文件的黑名单

### DIFF
--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -32,5 +32,5 @@ jobs:
         # 白名单 repo
         white_list: "CMT_CS_Learning"
         # 黑名单 repo
-        black_list: "Software-Test-Basis,maxface,LaTeX-Template"
+        black_list: "Software-Test-Basis,maxface,LaTeX-Template,cmt-cs-learning-website"
         # 取消码云禁止邮箱暴露


### PR DESCRIPTION
因为码云仓库仅仅自动同步 CMT_CS_Learning ，除此以外的所有仓库均不同步，因此将新建的前端项目添加到黑名单列表。